### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete URL substring sanitization

### DIFF
--- a/src/projects.js
+++ b/src/projects.js
@@ -51,7 +51,18 @@ function renderProjects(list) {
     const a = node.querySelector('.project-link');
     a.href = p.url || '#';
 
-    if (p.url.includes('github.com')) {
+    let isGitHubLink = false;
+    if (p.url) {
+      try {
+        const parsedUrl = new URL(p.url, window.location && window.location.origin ? window.location.origin : undefined);
+        const hostname = parsedUrl.hostname;
+        isGitHubLink = hostname === 'github.com' || hostname.endsWith('.github.com');
+      } catch (e) {
+        isGitHubLink = false;
+      }
+    }
+
+    if (isGitHubLink) {
       a.innerHTML = `GitHub ${arrowUpIcon}`;
     } else if (p.url) {
       a.innerHTML = `Live ${arrowUpIcon}`;


### PR DESCRIPTION
Potential fix for [https://github.com/ali-alhusseini/ali-alhusseini/security/code-scanning/3](https://github.com/ali-alhusseini/ali-alhusseini/security/code-scanning/3)

In general, the safe approach is to parse the URL and examine its host rather than using a substring search on the full URL string. For GitHub detection, we want to consider links that actually point to GitHub (e.g., `https://github.com/...` or `https://subdomain.github.com/...`) and not those that merely contain `github.com` elsewhere.

The best fix here is to derive a boolean like `isGitHubLink` by parsing `p.url` with the standard `URL` constructor (available in browsers) and then checking the `hostname` property for an exact match or proper subdomain relationship with `github.com`. We also need to guard against invalid URLs by catching exceptions and treating such cases as non-GitHub. This preserves existing functionality (classifying current GitHub links as such) but makes the classification robust and safe.

Concretely, inside `renderProjects`, around lines 51–60, we will:
- Leave `a.href = p.url || '#';` as is.
- Replace `if (p.url.includes('github.com')) { ... }` with:
  - A `let isGitHubLink = false;`
  - A `try { ... } catch { ... }` block that:
    - Constructs `new URL(p.url, window.location.origin)` so relative URLs also parse.
    - Extracts `url.hostname`.
    - Sets `isGitHubLink = hostname === 'github.com' || hostname.endsWith('.github.com');`.
- Use `if (isGitHubLink) { ... } else if (p.url) { ... } ...` for the display logic.

No new imports or external libraries are needed; `URL` is standard in browsers.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
